### PR TITLE
UPSTREAM 2811: Handle the migration to the new TXT format - create missing records

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -167,6 +167,9 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 		deprecatedRegistryErrors.Inc()
 		return err
 	}
+
+	missingRecords := c.Registry.MissingRecords()
+
 	registryEndpointsTotal.Set(float64(len(records)))
 	regARecords := filterARecords(records)
 	registryARecords.Set(float64(len(regARecords)))
@@ -189,6 +192,7 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 		Policies:           []plan.Policy{c.Policy},
 		Current:            records,
 		Desired:            endpoints,
+		Missing:            missingRecords,
 		DomainFilter:       endpoint.MatchAllDomainFilters{c.DomainFilter, c.Registry.GetDomainFilter()},
 		PropertyComparator: c.Registry.PropertyValuesEqual,
 		ManagedRecords:     c.ManagedRecordTypes,

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -7,7 +7,8 @@ It contains record type it manages, e.g.:
 
 Prefix and suffix are extended with %{record_type} template where the user can control how prefixed/suffixed records should look like.
 
-In order to maintain compatibility, both records will be maintained for some time, in order to have downgrade possibility.
+In order to maintain compatibility, both records will be maintained for some time, in order to have downgrade possibility.  
+The controller will try to create the "new format" TXT records if they are not present to ease the migration from the versions < 0.12.0.
 
 Later on, the old format will be dropped and only the new format will be kept (<record_type>-<endpoint_name>).
 

--- a/main.go
+++ b/main.go
@@ -341,7 +341,7 @@ func main() {
 	case "noop":
 		r, err = registry.NewNoopRegistry(p)
 	case "txt":
-		r, err = registry.NewTXTRegistry(p, cfg.TXTPrefix, cfg.TXTSuffix, cfg.TXTOwnerID, cfg.TXTCacheInterval, cfg.TXTWildcardReplacement)
+		r, err = registry.NewTXTRegistry(p, cfg.TXTPrefix, cfg.TXTSuffix, cfg.TXTOwnerID, cfg.TXTCacheInterval, cfg.TXTWildcardReplacement, cfg.ManagedDNSRecordTypes)
 	case "aws-sd":
 		r, err = registry.NewAWSSDRegistry(p.(*awssd.AWSSDProvider), cfg.TXTOwnerID)
 	default:

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -37,6 +37,8 @@ type Plan struct {
 	Current []*endpoint.Endpoint
 	// List of desired records
 	Desired []*endpoint.Endpoint
+	// List of missing records to be created, use for the migrations (e.g. old-new TXT format)
+	Missing []*endpoint.Endpoint
 	// Policies under which the desired changes are calculated
 	Policies []Policy
 	// List of changes necessary to move towards desired state
@@ -168,6 +170,11 @@ func (p *Plan) Calculate() *Plan {
 	}
 	for _, pol := range p.Policies {
 		changes = pol.Apply(changes)
+	}
+
+	// Handle the migration of the TXT records created before the new format (introduced in v0.12.0)
+	if len(p.Missing) > 0 {
+		changes.Create = append(changes.Create, filterRecordsForPlan(p.Missing, p.DomainFilter, append(p.ManagedRecords, endpoint.RecordTypeTXT))...)
 	}
 
 	plan := &Plan{

--- a/registry/aws_sd_registry.go
+++ b/registry/aws_sd_registry.go
@@ -67,6 +67,11 @@ func (sdr *AWSSDRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, er
 	return records, nil
 }
 
+// MissingRecords returns nil because there is no missing records for AWSSD registry
+func (sdr *AWSSDRegistry) MissingRecords() []*endpoint.Endpoint {
+	return nil
+}
+
 // ApplyChanges filters out records not owned the External-DNS, additionally it adds the required label
 // inserted in the AWS SD instance as a CreateID field
 func (sdr *AWSSDRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) error {

--- a/registry/noop.go
+++ b/registry/noop.go
@@ -45,6 +45,11 @@ func (im *NoopRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, erro
 	return im.provider.Records(ctx)
 }
 
+// MissingRecords returns nil because there is no missing records for Noop registry
+func (im *NoopRegistry) MissingRecords() []*endpoint.Endpoint {
+	return nil
+}
+
 // ApplyChanges propagates changes to the dns provider
 func (im *NoopRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
 	return im.provider.ApplyChanges(ctx, changes)

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -35,6 +35,7 @@ type Registry interface {
 	PropertyValuesEqual(attribute string, previous string, current string) bool
 	AdjustEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint
 	GetDomainFilter() endpoint.DomainFilterInterface
+	MissingRecords() []*endpoint.Endpoint
 }
 
 //TODO(ideahitme): consider moving this to Plan

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -47,10 +47,15 @@ type TXTRegistry struct {
 	// registry TXT records corresponding to wildcard records will be invalid (and rejected by most providers), due to
 	// having a '*' appear (not as the first character) - see https://tools.ietf.org/html/rfc1034#section-4.3.3
 	wildcardReplacement string
+
+	managedRecordTypes []string
+
+	// missingTXTRecords stores TXT records which are missing after the migration to the new format
+	missingTXTRecords []*endpoint.Endpoint
 }
 
 // NewTXTRegistry returns new TXTRegistry object
-func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID string, cacheInterval time.Duration, txtWildcardReplacement string) (*TXTRegistry, error) {
+func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID string, cacheInterval time.Duration, txtWildcardReplacement string, managedRecordTypes []string) (*TXTRegistry, error) {
 	if ownerID == "" {
 		return nil, errors.New("owner id cannot be empty")
 	}
@@ -67,6 +72,7 @@ func NewTXTRegistry(provider provider.Provider, txtPrefix, txtSuffix, ownerID st
 		mapper:              mapper,
 		cacheInterval:       cacheInterval,
 		wildcardReplacement: txtWildcardReplacement,
+		managedRecordTypes:  managedRecordTypes,
 	}, nil
 }
 
@@ -95,8 +101,10 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 	}
 
 	endpoints := []*endpoint.Endpoint{}
+	missingEndpoints := []*endpoint.Endpoint{}
 
 	labelMap := map[string]endpoint.Labels{}
+	txtRecordsMap := map[string]struct{}{}
 
 	for _, record := range records {
 		if record.RecordType != endpoint.RecordTypeTXT {
@@ -117,6 +125,7 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 		}
 		key := fmt.Sprintf("%s::%s", im.mapper.toEndpointName(record.DNSName), record.SetIdentifier)
 		labelMap[key] = labels
+		txtRecordsMap[record.DNSName] = struct{}{}
 	}
 
 	for _, ep := range endpoints {
@@ -135,6 +144,18 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 				ep.Labels[k] = v
 			}
 		}
+		// Handle the migration of TXT records created before the new format (introduced in v0.12.0)
+		if len(txtRecordsMap) > 0 {
+			if isManagedRecord(ep, im.managedRecordTypes) {
+				// get desired TXT records and detect the missing ones
+				for _, desiredTXT := range im.generateTXTRecord(ep) {
+					if _, exists := txtRecordsMap[desiredTXT.DNSName]; !exists {
+						// add missing TXT record
+						missingEndpoints = append(missingEndpoints, desiredTXT)
+					}
+				}
+			}
+		}
 	}
 
 	// Update the cache.
@@ -143,12 +164,25 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 		im.recordsCacheRefreshTime = time.Now()
 	}
 
+	im.missingTXTRecords = missingEndpoints
+
 	return endpoints, nil
+}
+
+// MissingRecords returns the TXT record to be created.
+// The missing records are collected during the run of Records method.
+func (im *TXTRegistry) MissingRecords() []*endpoint.Endpoint {
+	return im.missingTXTRecords
 }
 
 // generateTXTRecord generates both "old" and "new" TXT records.
 // Once we decide to drop old format we need to drop toTXTName() and rename toNewTXTName
 func (im *TXTRegistry) generateTXTRecord(r *endpoint.Endpoint) []*endpoint.Endpoint {
+	// missing TXT records are added to the set of changes,
+	// obviously we don't need any other TXT record for them
+	if r.RecordType == endpoint.RecordTypeTXT {
+		return nil
+	}
 	// old TXT record format
 	txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true)).WithSetIdentifier(r.SetIdentifier)
 	txt.ProviderSpecific = r.ProviderSpecific
@@ -396,4 +430,13 @@ func (im *TXTRegistry) removeFromCache(ep *endpoint.Endpoint) {
 			return
 		}
 	}
+}
+
+func isManagedRecord(record *endpoint.Endpoint, managedTypes []string) bool {
+	for _, mt := range managedTypes {
+		if record.RecordType == mt {
+			return true
+		}
+	}
+	return false
 }

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -41,24 +41,25 @@ func TestTXTRegistry(t *testing.T) {
 	t.Run("TestNewTXTRegistry", testTXTRegistryNew)
 	t.Run("TestRecords", testTXTRegistryRecords)
 	t.Run("TestApplyChanges", testTXTRegistryApplyChanges)
+	t.Run("TestMissingRecords", testTXTRegistryMissingRecords)
 }
 
 func testTXTRegistryNew(t *testing.T) {
 	p := inmemory.NewInMemoryProvider()
-	_, err := NewTXTRegistry(p, "txt", "", "", time.Hour, "")
+	_, err := NewTXTRegistry(p, "txt", "", "", time.Hour, "", []string{})
 	require.Error(t, err)
 
-	_, err = NewTXTRegistry(p, "", "txt", "", time.Hour, "")
+	_, err = NewTXTRegistry(p, "", "txt", "", time.Hour, "", []string{})
 	require.Error(t, err)
 
-	r, err := NewTXTRegistry(p, "txt", "", "owner", time.Hour, "")
+	r, err := NewTXTRegistry(p, "txt", "", "owner", time.Hour, "", []string{})
 	require.NoError(t, err)
 	assert.Equal(t, p, r.provider)
 
-	r, err = NewTXTRegistry(p, "", "txt", "owner", time.Hour, "")
+	r, err = NewTXTRegistry(p, "", "txt", "owner", time.Hour, "", []string{})
 	require.NoError(t, err)
 
-	_, err = NewTXTRegistry(p, "txt", "txt", "owner", time.Hour, "")
+	_, err = NewTXTRegistry(p, "txt", "txt", "owner", time.Hour, "", []string{})
 	require.Error(t, err)
 
 	_, ok := r.mapper.(affixNameMapper)
@@ -66,7 +67,7 @@ func testTXTRegistryNew(t *testing.T) {
 	assert.Equal(t, "owner", r.ownerID)
 	assert.Equal(t, p, r.provider)
 
-	r, err = NewTXTRegistry(p, "", "", "owner", time.Hour, "")
+	r, err = NewTXTRegistry(p, "", "", "owner", time.Hour, "", []string{})
 	require.NoError(t, err)
 
 	_, ok = r.mapper.(affixNameMapper)
@@ -182,13 +183,13 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 		},
 	}
 
-	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "wc")
+	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "wc", []string{})
 	records, _ := r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
 
 	// Ensure prefix is case-insensitive
-	r, _ = NewTXTRegistry(p, "TxT.", "", "owner", time.Hour, "")
+	r, _ = NewTXTRegistry(p, "TxT.", "", "owner", time.Hour, "", []string{})
 	records, _ = r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpointLabels(records, expectedRecords))
@@ -287,13 +288,13 @@ func testTXTRegistryRecordsSuffixed(t *testing.T) {
 		},
 	}
 
-	r, _ := NewTXTRegistry(p, "", "-txt", "owner", time.Hour, "")
+	r, _ := NewTXTRegistry(p, "", "-txt", "owner", time.Hour, "", []string{})
 	records, _ := r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
 
 	// Ensure prefix is case-insensitive
-	r, _ = NewTXTRegistry(p, "", "-TxT", "owner", time.Hour, "")
+	r, _ = NewTXTRegistry(p, "", "-TxT", "owner", time.Hour, "", []string{})
 	records, _ = r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpointLabels(records, expectedRecords))
@@ -368,7 +369,7 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 		},
 	}
 
-	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "")
+	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "", []string{})
 	records, _ := r.Records(ctx)
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
@@ -411,7 +412,7 @@ func testTXTRegistryApplyChangesWithPrefix(t *testing.T) {
 			newEndpointWithOwner("txt.cname-multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
 		},
 	})
-	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "")
+	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "", []string{})
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
@@ -500,7 +501,7 @@ func testTXTRegistryApplyChangesWithTemplatedPrefix(t *testing.T) {
 	p.ApplyChanges(ctx, &plan.Changes{
 		Create: []*endpoint.Endpoint{},
 	})
-	r, _ := NewTXTRegistry(p, "prefix%{record_type}.", "", "owner", time.Hour, "")
+	r, _ := NewTXTRegistry(p, "prefix%{record_type}.", "", "owner", time.Hour, "", []string{})
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "", "ingress/default/my-ingress"),
@@ -543,7 +544,7 @@ func testTXTRegistryApplyChangesWithTemplatedSuffix(t *testing.T) {
 	p.OnApplyChanges = func(ctx context.Context, got *plan.Changes) {
 		assert.Equal(t, ctxEndpoints, ctx.Value(provider.RecordsContextKey))
 	}
-	r, _ := NewTXTRegistry(p, "", "-%{record_type}suffix", "owner", time.Hour, "")
+	r, _ := NewTXTRegistry(p, "", "-%{record_type}suffix", "owner", time.Hour, "", []string{})
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "", "ingress/default/my-ingress"),
@@ -608,7 +609,7 @@ func testTXTRegistryApplyChangesWithSuffix(t *testing.T) {
 			newEndpointWithOwner("cname-multiple-txt.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
 		},
 	})
-	r, _ := NewTXTRegistry(p, "", "-txt", "owner", time.Hour, "wildcard")
+	r, _ := NewTXTRegistry(p, "", "-txt", "owner", time.Hour, "wildcard", []string{})
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
@@ -712,7 +713,7 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 			newEndpointWithOwner("cname-foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
 	})
-	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "")
+	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "", []string{})
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
@@ -764,6 +765,161 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 	}
 	err := r.ApplyChanges(ctx, changes)
 	require.NoError(t, err)
+}
+
+func testTXTRegistryMissingRecords(t *testing.T) {
+	t.Run("No prefix", testTXTRegistryMissingRecordsNoPrefix)
+	t.Run("With Prefix", testTXTRegistryMissingRecordsWithPrefix)
+}
+
+func testTXTRegistryMissingRecordsNoPrefix(t *testing.T) {
+	ctx := context.Background()
+	p := inmemory.NewInMemoryProvider()
+	p.CreateZone(testZone)
+	p.ApplyChanges(ctx, &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			newEndpointWithOwner("oldformat.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("oldformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("oldformat2.test-zone.example.org", "bar.loadbalancer.com", endpoint.RecordTypeA, ""),
+			newEndpointWithOwner("oldformat2.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("newformat.test-zone.example.org", "foobar.nameserver.com", endpoint.RecordTypeNS, ""),
+			newEndpointWithOwner("ns-newformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("newformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("noheritage.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
+		},
+	})
+	expectedRecords := []*endpoint.Endpoint{
+		{
+			DNSName:    "oldformat.test-zone.example.org",
+			Targets:    endpoint.Targets{"foo.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeCNAME,
+			Labels: map[string]string{
+				// owner was added from the TXT record's target
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
+			DNSName:    "oldformat2.test-zone.example.org",
+			Targets:    endpoint.Targets{"bar.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeA,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
+			DNSName:    "newformat.test-zone.example.org",
+			Targets:    endpoint.Targets{"foobar.nameserver.com"},
+			RecordType: endpoint.RecordTypeNS,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
+			DNSName:    "noheritage.test-zone.example.org",
+			Targets:    endpoint.Targets{"random"},
+			RecordType: endpoint.RecordTypeTXT,
+			Labels: map[string]string{
+				// No owner because it's not external-dns heritage
+				endpoint.OwnerLabelKey: "",
+			},
+		},
+	}
+
+	expectedMissingRecords := []*endpoint.Endpoint{
+		{
+			DNSName: "cname-oldformat.test-zone.example.org",
+			// owner is taken from the source record (A, CNAME, etc.)
+			Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
+			RecordType: endpoint.RecordTypeTXT,
+		},
+		{
+			DNSName:    "a-oldformat2.test-zone.example.org",
+			Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
+			RecordType: endpoint.RecordTypeTXT,
+		},
+	}
+
+	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "wc", []string{endpoint.RecordTypeCNAME, endpoint.RecordTypeA, endpoint.RecordTypeNS})
+	records, _ := r.Records(ctx)
+	missingRecords := r.MissingRecords()
+
+	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
+	assert.True(t, testutils.SameEndpoints(missingRecords, expectedMissingRecords))
+}
+
+func testTXTRegistryMissingRecordsWithPrefix(t *testing.T) {
+	ctx := context.Background()
+	p := inmemory.NewInMemoryProvider()
+	p.CreateZone(testZone)
+	p.ApplyChanges(ctx, &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			newEndpointWithOwner("oldformat.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("txt.oldformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("oldformat2.test-zone.example.org", "bar.loadbalancer.com", endpoint.RecordTypeA, ""),
+			newEndpointWithOwner("txt.oldformat2.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("newformat.test-zone.example.org", "foobar.nameserver.com", endpoint.RecordTypeNS, ""),
+			newEndpointWithOwner("txt.ns-newformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("txt.newformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("noheritage.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
+		},
+	})
+	expectedRecords := []*endpoint.Endpoint{
+		{
+			DNSName:    "oldformat.test-zone.example.org",
+			Targets:    endpoint.Targets{"foo.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeCNAME,
+			Labels: map[string]string{
+				// owner was added from the TXT record's target
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
+			DNSName:    "oldformat2.test-zone.example.org",
+			Targets:    endpoint.Targets{"bar.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeA,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
+			DNSName:    "newformat.test-zone.example.org",
+			Targets:    endpoint.Targets{"foobar.nameserver.com"},
+			RecordType: endpoint.RecordTypeNS,
+			Labels: map[string]string{
+				endpoint.OwnerLabelKey: "owner",
+			},
+		},
+		{
+			DNSName:    "noheritage.test-zone.example.org",
+			Targets:    endpoint.Targets{"random"},
+			RecordType: endpoint.RecordTypeTXT,
+			Labels: map[string]string{
+				// No owner because it's not external-dns heritage
+				endpoint.OwnerLabelKey: "",
+			},
+		},
+	}
+
+	expectedMissingRecords := []*endpoint.Endpoint{
+		{
+			DNSName: "txt.cname-oldformat.test-zone.example.org",
+			// owner is taken from the source record (A, CNAME, etc.)
+			Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
+			RecordType: endpoint.RecordTypeTXT,
+		},
+		{
+			DNSName:    "txt.a-oldformat2.test-zone.example.org",
+			Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
+			RecordType: endpoint.RecordTypeTXT,
+		},
+	}
+
+	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "wc", []string{endpoint.RecordTypeCNAME, endpoint.RecordTypeA, endpoint.RecordTypeNS})
+	records, _ := r.Records(ctx)
+	missingRecords := r.MissingRecords()
+
+	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
+	assert.True(t, testutils.SameEndpoints(missingRecords, expectedMissingRecords))
 }
 
 func TestCacheMethods(t *testing.T) {
@@ -877,7 +1033,7 @@ func TestNewTXTScheme(t *testing.T) {
 			newEndpointWithOwner("cname-foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
 	})
-	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "")
+	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "", []string{})
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
@@ -938,18 +1094,18 @@ func TestGenerateTXT(t *testing.T) {
 			DNSName:    "foo.test-zone.example.org",
 			Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
 			RecordType: endpoint.RecordTypeTXT,
-			Labels: map[string]string{},
+			Labels:     map[string]string{},
 		},
 		{
 			DNSName:    "cname-foo.test-zone.example.org",
 			Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
 			RecordType: endpoint.RecordTypeTXT,
-			Labels: map[string]string{},
+			Labels:     map[string]string{},
 		},
 	}
 	p := inmemory.NewInMemoryProvider()
 	p.CreateZone(testZone)
-	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "")
+	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "", []string{})
 	gotTXT := r.generateTXTRecord(record)
 	assert.Equal(t, expectedTXT, gotTXT)
 }


### PR DESCRIPTION
Carry patch of not yet merged fix: https://github.com/kubernetes-sigs/external-dns/pull/2811
Test of this patch: https://github.com/openshift/external-dns-operator/pull/163