### PR TITLE
UPSTREAM 2811: Handle the migration to the new TXT format. Catch up to the merged version

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -257,7 +257,7 @@ func filterRecordsForPlan(records []*endpoint.Endpoint, domainFilter endpoint.Do
 			log.Debugf("ignoring record %s that does not match domain filter", record.DNSName)
 			continue
 		}
-		if isManagedRecord(record.RecordType, managedRecords) {
+		if IsManagedRecord(record.RecordType, managedRecords) {
 			filtered = append(filtered, record)
 		}
 	}
@@ -300,7 +300,7 @@ func CompareBoolean(defaultValue bool, name, current, previous string) bool {
 	return v1 == v2
 }
 
-func isManagedRecord(record string, managedRecords []string) bool {
+func IsManagedRecord(record string, managedRecords []string) bool {
 	for _, r := range managedRecords {
 		if record == r {
 			return true

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -144,15 +144,23 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 				ep.Labels[k] = v
 			}
 		}
-		// Handle the migration of TXT records created before the new format (introduced in v0.12.0)
-		if len(txtRecordsMap) > 0 {
-			if isManagedRecord(ep, im.managedRecordTypes) {
-				// get desired TXT records and detect the missing ones
-				for _, desiredTXT := range im.generateTXTRecord(ep) {
+
+		// Handle the migration of TXT records created before the new format (introduced in v0.12.0).
+		// The migration is done for the TXT records owned by this instance only.
+		if len(txtRecordsMap) > 0 && ep.Labels[endpoint.OwnerLabelKey] == im.ownerID {
+			if plan.IsManagedRecord(ep.RecordType, im.managedRecordTypes) {
+				// Get desired TXT records and detect the missing ones
+				desiredTXTs := im.generateTXTRecord(ep)
+				missingDesiredTXTs := []*endpoint.Endpoint{}
+				for _, desiredTXT := range desiredTXTs {
 					if _, exists := txtRecordsMap[desiredTXT.DNSName]; !exists {
-						// add missing TXT record
-						missingEndpoints = append(missingEndpoints, desiredTXT)
+						missingDesiredTXTs = append(missingDesiredTXTs, desiredTXT)
 					}
+				}
+				if len(desiredTXTs) > len(missingDesiredTXTs) {
+					// Add missing TXT records only if those are managed (by externaldns) ones.
+					// The unmanaged record has both of the desired TXT records missing.
+					missingEndpoints = append(missingEndpoints, missingDesiredTXTs...)
 				}
 			}
 		}
@@ -178,8 +186,8 @@ func (im *TXTRegistry) MissingRecords() []*endpoint.Endpoint {
 // generateTXTRecord generates both "old" and "new" TXT records.
 // Once we decide to drop old format we need to drop toTXTName() and rename toNewTXTName
 func (im *TXTRegistry) generateTXTRecord(r *endpoint.Endpoint) []*endpoint.Endpoint {
-	// missing TXT records are added to the set of changes,
-	// obviously we don't need any other TXT record for them
+	// Missing TXT records are added to the set of changes.
+	// Obviously, we don't need any other TXT record for them.
 	if r.RecordType == endpoint.RecordTypeTXT {
 		return nil
 	}

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -786,6 +786,10 @@ func testTXTRegistryMissingRecordsNoPrefix(t *testing.T) {
 			newEndpointWithOwner("ns-newformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("newformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("noheritage.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("oldformat-otherowner.test-zone.example.org", "bar.loadbalancer.com", endpoint.RecordTypeA, ""),
+			newEndpointWithOwner("oldformat-otherowner.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=otherowner\"", endpoint.RecordTypeTXT, ""),
+			endpoint.NewEndpoint("unmanaged1.test-zone.example.org", endpoint.RecordTypeA, "unmanaged1.loadbalancer.com"),
+			endpoint.NewEndpoint("unmanaged2.test-zone.example.org", endpoint.RecordTypeCNAME, "unmanaged2.loadbalancer.com"),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
@@ -814,6 +818,7 @@ func testTXTRegistryMissingRecordsNoPrefix(t *testing.T) {
 				endpoint.OwnerLabelKey: "owner",
 			},
 		},
+		// Only TXT records with the wrong heritage are returned by Records()
 		{
 			DNSName:    "noheritage.test-zone.example.org",
 			Targets:    endpoint.Targets{"random"},
@@ -822,6 +827,25 @@ func testTXTRegistryMissingRecordsNoPrefix(t *testing.T) {
 				// No owner because it's not external-dns heritage
 				endpoint.OwnerLabelKey: "",
 			},
+		},
+		{
+			DNSName:    "oldformat-otherowner.test-zone.example.org",
+			Targets:    endpoint.Targets{"bar.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeA,
+			Labels: map[string]string{
+				// Records() retrieves all the records of the zone, no matter the owner
+				endpoint.OwnerLabelKey: "otherowner",
+			},
+		},
+		{
+			DNSName:    "unmanaged1.test-zone.example.org",
+			Targets:    endpoint.Targets{"unmanaged1.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeA,
+		},
+		{
+			DNSName:    "unmanaged2.test-zone.example.org",
+			Targets:    endpoint.Targets{"unmanaged2.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeCNAME,
 		},
 	}
 
@@ -861,6 +885,10 @@ func testTXTRegistryMissingRecordsWithPrefix(t *testing.T) {
 			newEndpointWithOwner("txt.ns-newformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("txt.newformat.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("noheritage.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("oldformat-otherowner.test-zone.example.org", "bar.loadbalancer.com", endpoint.RecordTypeA, ""),
+			newEndpointWithOwner("txt.oldformat-otherowner.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=otherowner\"", endpoint.RecordTypeTXT, ""),
+			endpoint.NewEndpoint("unmanaged1.test-zone.example.org", endpoint.RecordTypeA, "unmanaged1.loadbalancer.com"),
+			endpoint.NewEndpoint("unmanaged2.test-zone.example.org", endpoint.RecordTypeCNAME, "unmanaged2.loadbalancer.com"),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
@@ -897,6 +925,25 @@ func testTXTRegistryMissingRecordsWithPrefix(t *testing.T) {
 				// No owner because it's not external-dns heritage
 				endpoint.OwnerLabelKey: "",
 			},
+		},
+		{
+			DNSName:    "oldformat-otherowner.test-zone.example.org",
+			Targets:    endpoint.Targets{"bar.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeA,
+			Labels: map[string]string{
+				// All the records of the zone are retrieved, no matter the owner
+				endpoint.OwnerLabelKey: "otherowner",
+			},
+		},
+		{
+			DNSName:    "unmanaged1.test-zone.example.org",
+			Targets:    endpoint.Targets{"unmanaged1.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeA,
+		},
+		{
+			DNSName:    "unmanaged2.test-zone.example.org",
+			Targets:    endpoint.Targets{"unmanaged2.loadbalancer.com"},
+			RecordType: endpoint.RecordTypeCNAME,
 		},
 	}
 


### PR DESCRIPTION
The merged version of the upstream https://github.com/kubernetes-sigs/external-dns/pull/2811 drifted from the cherry pick we used in https://github.com/openshift/external-dns/pull/43.
The goal of this PR is to catch up on this drift.


Test PR: https://github.com/openshift/external-dns-operator/pull/167