### PR TITLE
OCPBUGS-41683: UPSTREAM: <carry>: openshift: Use RHEL9 for base and building images

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.22-openshift-4.17
+  tag: rhel-9-release-golang-1.22-openshift-4.17

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 WORKDIR /sigs.k8s.io/external-dns
 COPY . .
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/4.17:base
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /usr/bin/
 ENTRYPOINT ["/usr/bin/external-dns"]
 LABEL io.openshift.release.operator="true"


### PR DESCRIPTION
Change RHEL version to RHEL9 for building and base images.