### PR TITLE
OCPBUGS-57188: UPSTREAM: <5013>: Fix failing test relying on example.com domain resolution

### DIFF
--- a/internal/testutils/endpoint.go
+++ b/internal/testutils/endpoint.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testutils
 
 import (
+	"net/netip"
 	"reflect"
 	"sort"
 
@@ -121,4 +122,13 @@ func SameProviderSpecific(a, b endpoint.ProviderSpecific) bool {
 	sort.Sort(byNames(sa))
 	sort.Sort(byNames(sb))
 	return reflect.DeepEqual(sa, sb)
+}
+
+// NewTargetsFromAddr convert an array of netip.Addr to Targets (array of string)
+func NewTargetsFromAddr(targets []netip.Addr) endpoint.Targets {
+	t := make(endpoint.Targets, len(targets))
+	for i, target := range targets {
+		t[i] = target.String()
+	}
+	return t
 }

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/internal/testutils"
 )
 
 type ServiceSuite struct {
@@ -411,8 +412,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			serviceTypesFilter:          []string{},
 			resolveLoadBalancerHostname: true,
 			expected: []*endpoint.Endpoint{
-				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: endpoint.Targets{exampleDotComIP4[0].String()}},
-				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: endpoint.Targets{exampleDotComIP6[0].String()}},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeA, Targets: testutils.NewTargetsFromAddr(exampleDotComIP4)},
+				{DNSName: "foo.example.org", RecordType: endpoint.RecordTypeAAAA, Targets: testutils.NewTargetsFromAddr(exampleDotComIP6)},
 			},
 		},
 		{


### PR DESCRIPTION
`TestServiceSource/Endpoints` uses the `example.com` domain, which now resolves to multiple IP addresses instead of a single one as previously expected. This causes the test to fail.

Example of the failure: [link](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_external-dns/62/pull-ci-openshift-external-dns-master-unit/1930995963904659456).
This patch can be dropped on the next rebase if https://github.com/kubernetes-sigs/external-dns/pull/5013 will be in the rebase.
