### PR TITLE
NE-2053: Add dedicated Containerfile for Konflux builds

### DIFF
--- a/Containerfile.externaldns
+++ b/Containerfile.externaldns
@@ -1,0 +1,28 @@
+# Detect the drift from the upstream Dockerfile
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS drift
+WORKDIR /app
+COPY drift-cache/Dockerfile Dockerfile.cached
+COPY Dockerfile.openshift Dockerfile
+# If the command below fails it means that the Dockerfile from this repository changed.
+# You have to update the Konflux Containerfile accordingly.
+# drift-cache/Dockerfile can be updated with the upstream contents once the Konflux version is aligned.
+RUN [ "$(sha1sum Dockerfile.cached | cut -d' ' -f1)" = "$(sha1sum Dockerfile | cut -d' ' -f1)" ]
+
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22 as builder
+# dummy copy to trigger the drift detection
+COPY --from=drift /app/Dockerfile.cached .
+COPY . /workspace
+WORKDIR /workspace
+RUN git config --global --add safe.directory /workspace
+# Build
+RUN make build
+
+FROM registry.redhat.io/rhel9-4-els/rhel:9.4-943.1729773477
+LABEL maintainer="Red Hat, Inc."
+LABEL com.redhat.component="external-dns-container"
+LABEL name="external-dns"
+LABEL version="1.3.0"
+LABEL commit="76d92ad82b22c92c191a8c0145d3712e4012d987"
+WORKDIR /
+COPY --from=builder /workspace/build/external-dns /
+ENTRYPOINT ["/external-dns"]

--- a/drift-cache/Dockerfile
+++ b/drift-cache/Dockerfile
@@ -1,0 +1,12 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
+WORKDIR /sigs.k8s.io/external-dns
+COPY . .
+RUN make build
+
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
+COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /usr/bin/
+ENTRYPOINT ["/usr/bin/external-dns"]
+LABEL io.openshift.release.operator="true"
+LABEL io.k8s.display-name="Kubernetes ExternalDNS" \
+      io.k8s.description="Synchronizes exposed Kubernetes Services and Ingresses with DNS providers." \
+      maintainer="<aos-network-edge-staff@redhat.com>"


### PR DESCRIPTION
This commit adds a dedicated Containerfile that can be referenced by the Konflux operand component. It automatically detects drift from the `Dockerfile.openshift`, thereby enforcing synchronization between the version used in CI presubmits and Konflux.

The base image used matches the minor version that was in use in CPaaS at the time the migration to Konflux began. This ensures continuity with previous releases.

The builder image, on the other hand, has been set to `registry.access.redhat.com/ubi9/go-toolset` to avoid relying on `registry-proxy.engineering.redhat.com` (used in CPaaS) and to stay consistent with the builder image samples recommended by the Konflux migration team.

Reference Dockerfile from CPaaS: [link](https://gitlab.cee.redhat.com/cpaas-midstream/external-dns-operator/-/blob/ext-dns-optr-1.3-rhel-9/distgit/containers/external-dns/Dockerfile.in?ref_type=heads).
