### PR TITLE
NE-2053: UPSTREAM: <carry>: Add non-root user to Containerfile

### DIFF
--- a/Containerfile.externaldns
+++ b/Containerfile.externaldns
@@ -33,4 +33,5 @@ LABEL commit="76d92ad82b22c92c191a8c0145d3712e4012d987"
 WORKDIR /
 COPY --from=builder /workspace/build/external-dns /
 COPY LICENSE /licenses/
+USER 65532:65532
 ENTRYPOINT ["/external-dns"]


### PR DESCRIPTION
Add USER instruction to the main stage of Containerfile to comply with Red Hat certified image requirements.

Task with the warning: [link](https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/external-dns-operator-tenant/applications/external-dns-operator/taskruns/external-dns-container-on-pull-8463945d25d885649b00ee5a17944eda/logs).
Knowledge base article: [link](https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction).

