### PR TITLE
UPSTREAM: <carry>: NE-2054: Add bundle nudging configuration to push pipeline

### DIFF
--- a/.tekton/external-dns-container-ext-dns-optr-1-3-rhel-9-push.yaml
+++ b/.tekton/external-dns-container-ext-dns-optr-1-3-rhel-9-push.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: bundle-hack/container_digest.sh
     build.appstudio.openshift.io/repo: https://github.com/openshift/external-dns?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'


### PR DESCRIPTION
Nudging enables dependencies between Konflux components.

When a new externaldns image is built, Konflux will automatically create a PR to update the operator bundle's digest in bundle-hack/container_digest.sh.