### PR TITLE
NE-2142: Bump golang to 1.24

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.17
+  tag: rhel-9-release-golang-1.24-openshift-4.21

--- a/Containerfile.externaldns
+++ b/Containerfile.externaldns
@@ -8,7 +8,7 @@ COPY Dockerfile.openshift Dockerfile
 # drift-cache/Dockerfile can be updated with the upstream contents once the Konflux version is aligned.
 RUN test "$(sha1sum Dockerfile.cached | cut -d' ' -f1)" = "$(sha1sum Dockerfile | cut -d' ' -f1)"
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.22 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 as builder
 # dummy copy to trigger the drift detection
 COPY --from=drift /app/Dockerfile.cached .
 WORKDIR /workspace

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
+FROM golang:1.24 as builder
 WORKDIR /sigs.k8s.io/external-dns
 COPY . .
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /usr/bin/
 ENTRYPOINT ["/usr/bin/external-dns"]
 LABEL io.openshift.release.operator="true"

--- a/drift-cache/Dockerfile
+++ b/drift-cache/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
+FROM golang:1.24 as builder
 WORKDIR /sigs.k8s.io/external-dns
 COPY . .
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /usr/bin/
 ENTRYPOINT ["/usr/bin/external-dns"]
 LABEL io.openshift.release.operator="true"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/external-dns
 
-go 1.22.2
+go 1.24.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.3.0

--- a/provider/bluecat/gateway/api_test.go
+++ b/provider/bluecat/gateway/api_test.go
@@ -55,7 +55,7 @@ func TestBluecatExpandZones(t *testing.T) {
 			got := expandZone(tc.input)
 			diff := cmp.Diff(tc.want, got)
 			if diff != "" {
-				t.Fatalf(diff)
+				t.Fatalf("%s", diff)
 			}
 		})
 	}
@@ -91,7 +91,7 @@ func TestBluecatSplitProperties(t *testing.T) {
 			got := SplitProperties(tc.input)
 			diff := cmp.Diff(tc.want, got)
 			if diff != "" {
-				t.Fatalf(diff)
+				t.Fatalf("%s", diff)
 			}
 		})
 	}

--- a/provider/tencentcloud/cloudapi/tencentapi.go
+++ b/provider/tencentcloud/cloudapi/tencentapi.go
@@ -258,7 +258,7 @@ func dealWithError(action Action, request string, err error) bool {
 }
 
 func APIErrorRecord(apiAction Action, request string, response string, err error) {
-	log.Infof(fmt.Sprintf("APIError API: %s/%s Request: %s, Response: %s, Error: %s", apiAction.Service, apiAction.Name, request, response, err.Error()))
+	log.Infof("APIError API: %s/%s Request: %s, Response: %s, Error: %s", apiAction.Service, apiAction.Name, request, response, err.Error())
 }
 
 func APIRecord(apiAction Action, request string, response string) {
@@ -267,7 +267,7 @@ func APIRecord(apiAction Action, request string, response string) {
 	if apiAction.ReadOnly {
 		// log.Infof(message)
 	} else {
-		log.Infof(message)
+		log.Infof("%s", message)
 	}
 }
 

--- a/provider/vinyldns/vinyldns.go
+++ b/provider/vinyldns/vinyldns.go
@@ -92,7 +92,7 @@ func (p *vinyldnsProvider) Records(ctx context.Context) (endpoints []*endpoint.E
 			continue
 		}
 
-		log.Infof(fmt.Sprintf("Zone: [%s:%s]", zone.ID, zone.Name))
+		log.Infof("Zone: [%s:%s]", zone.ID, zone.Name)
 		records, err := p.client.RecordSets(zone.ID)
 		if err != nil {
 			return nil, err
@@ -101,7 +101,7 @@ func (p *vinyldnsProvider) Records(ctx context.Context) (endpoints []*endpoint.E
 		for _, r := range records {
 			if provider.SupportedRecordType(r.Type) {
 				recordsCount := len(r.Records)
-				log.Debugf(fmt.Sprintf("%s.%s.%d.%s", r.Name, r.Type, recordsCount, zone.Name))
+				log.Debugf("%s.%s.%d.%s", r.Name, r.Type, recordsCount, zone.Name)
 
 				// TODO: AAAA Records
 				if len(r.Records) > 0 {

--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,7 @@
       ]
     },
     {
-      "description": "Keep Go toolset on minor version 1.22",
+      "description": "Keep Go toolset on minor version 1.24",
       "matchManagers": ["dockerfile"],
       "matchFileNames": [
         "Containerfile.externaldns"
@@ -38,7 +38,7 @@
       ],
       "enabled": true,
       "versioning": "redhat",
-      "allowedVersions": "/^1\\.22(\\.|$)/",
+      "allowedVersions": "/^1\\.24(\\.|$)/",
       "schedule": [
         "after 5am on tuesday"
       ]


### PR DESCRIPTION
- Bump Golang to `1.24`
- Replace the CI golang images with public ones, similar to the operator repository.
This change is supposed to prevent `registry-replacer` (https://github.com/openshift/ci-tools/tree/main/cmd/registry-replacer) from modifying the CI presubmit configuration of external-dns. `registry-replacer` regularly injects builder images into the external-dns CI configuration in `openshift/release` repository, but we want to maintain full control of that configuration directly from this source repository instead. Related thread about `registry-replacer`: [link](https://redhat-internal.slack.com/archives/CBN38N3MW/p1722852314171909).
- Update the code of some providers to conform to the new requirement of golang `1.24` to use constant for format strings.
- Update `renovate.json` to limit Konflux gotoolchain bumps to the new minor version: `1.24`.