### PR TITLE
UPSTREAM: <carry>: NE-2142: Use UBI image instead UBI micro

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -3,7 +3,7 @@ WORKDIR /sigs.k8s.io/external-dns
 COPY . .
 RUN make build
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+FROM registry.access.redhat.com/ubi9/ubi:latest
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /usr/bin/
 ENTRYPOINT ["/usr/bin/external-dns"]
 LABEL io.openshift.release.operator="true"

--- a/drift-cache/Dockerfile
+++ b/drift-cache/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /sigs.k8s.io/external-dns
 COPY . .
 RUN make build
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+FROM registry.access.redhat.com/ubi9/ubi:latest
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /usr/bin/
 ENTRYPOINT ["/usr/bin/external-dns"]
 LABEL io.openshift.release.operator="true"


### PR DESCRIPTION
UBI micro image doesn't have CA certificates necessary to talk to cloud provider APIs (AWS, GCP, Azure).