### PR TITLE
NO-JIRA: UPSTREAM: <carry>: DOWNSTREAM_OWNERS - Add new NI&D members

### DIFF
--- a/DOWNSTREAM_OWNERS
+++ b/DOWNSTREAM_OWNERS
@@ -7,15 +7,16 @@ approvers:
   - gcs278
   - grzpiotrowski
   - Thealisyed
-  - rohara
+  - rikatz
+  - davidesalerno
+  - bentito
 reviewers:
-  - knobunc
-  - Miciah
-  - candita
   - rfredette
   - alebedev87
   - gcs278
   - grzpiotrowski
   - Thealisyed
-  - rohara
+  - rikatz
+  - davidesalerno
+  - bentito
 component: DNS


### PR DESCRIPTION
This commit adds new NI&D members to approvers and removes some people (staff/management/architect) from reviewers to avoid default reviewer ping.