### PR TITLE
NE-2208: Switch base image to ubi9/ubi-minimal

### DIFF
--- a/Containerfile.externaldns
+++ b/Containerfile.externaldns
@@ -24,7 +24,7 @@ RUN git config --global --add safe.directory /workspace
 # Build
 RUN make build
 
-FROM registry.access.redhat.com/ubi9/ubi:9.6-1760340943
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:61d5ad475048c2e655cd46d0a55dfeaec182cc3faa6348cb85989a7c9e196483
 ARG FULL_COMMIT
 LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="external-dns-container"

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -3,7 +3,7 @@ WORKDIR /sigs.k8s.io/external-dns
 COPY . .
 RUN make build
 
-FROM registry.access.redhat.com/ubi9/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /usr/bin/
 ENTRYPOINT ["/usr/bin/external-dns"]
 LABEL io.openshift.release.operator="true"

--- a/drift-cache/Dockerfile
+++ b/drift-cache/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /sigs.k8s.io/external-dns
 COPY . .
 RUN make build
 
-FROM registry.access.redhat.com/ubi9/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /usr/bin/
 ENTRYPOINT ["/usr/bin/external-dns"]
 LABEL io.openshift.release.operator="true"

--- a/renovate.json
+++ b/renovate.json
@@ -16,12 +16,10 @@
       ],
       "matchDatasources": ["docker"],
       "matchPackageNames": [
-        "registry.access.redhat.com/ubi9/ubi-minimal",
-        "registry.access.redhat.com/ubi9/ubi"
+        "registry.access.redhat.com/ubi9/ubi-minimal"
       ],
       "enabled": true,
       "versioning": "redhat",
-      "allowedVersions": "/^9(\\.|$)/",
       "schedule": [
         "after 5am on tuesday"
       ]


### PR DESCRIPTION
- Update Containerfile.externaldns to use ubi-minimal:latest with pinned digest
- Update Dockerfile.openshift to use ubi-minimal:latest
- Update renovate.json to track only ubi-minimal and remove version restrictions

🤖 Generated with [Claude Code](https://claude.com/claude-code)