### PR TITLE
UPSTREAM: <carry>: openshift: DOWNSTREAM_OWNERS - add Ali and Greg

### DIFF
--- a/DOWNSTREAM_OWNERS
+++ b/DOWNSTREAM_OWNERS
@@ -1,19 +1,16 @@
 approvers:
   - knobunc
   - Miciah
-  - frobware
   - candita
   - rfredette
   - alebedev87
-  - miheer
   - gcs278
+  - grzpiotrowski
+  - Thealisyed
 reviewers:
-  - knobunc
-  - Miciah
-  - frobware
-  - candita
   - rfredette
   - alebedev87
-  - miheer
   - gcs278
+  - grzpiotrowski
+  - Thealisyed
 component: DNS


### PR DESCRIPTION
This commit also removes Miheer and Andy from approvers and reviewers. And removes Miciah, Ben and Candace from reviewers to reduce the amount of notifications for them.
