### PR TITLE
UPSTREAM: <carry>: OCPBUGS-24656: Ensure FIPS compliance for operand image

### DIFF
--- a/Containerfile.externaldns
+++ b/Containerfile.externaldns
@@ -21,8 +21,8 @@ WORKDIR /workspace
 RUN ls .
 COPY . /workspace
 RUN git config --global --add safe.directory /workspace
-# Build
-RUN make build
+# Build with FIPS compliance
+RUN make build.fips
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:161a4e29ea482bab6048c2b36031b4f302ae81e4ff18b83e61785f40dc576f5d
 ARG FULL_COMMIT

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,7 +1,8 @@
-FROM golang:1.24 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 as builder
 WORKDIR /sigs.k8s.io/external-dns
 COPY . .
-RUN make build
+RUN git config --global --add safe.directory /sigs.k8s.io/external-dns
+RUN make build.fips
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /usr/bin/

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,13 @@ build: build/$(BINARY)
 build/$(BINARY): $(SOURCES)
 	CGO_ENABLED=0 go build -o build/$(BINARY) $(BUILD_FLAGS) -ldflags "$(LDFLAGS)" .
 
+# Downstream FIPS-compliant build
+.PHONY: build.fips
+build.fips: build.fips/$(BINARY)
+
+build.fips/$(BINARY): $(SOURCES)
+	CGO_ENABLED=1 go build -tags strictfipsruntime -o build/$(BINARY) $(BUILD_FLAGS) -ldflags "$(LDFLAGS)" .
+
 build.push/multiarch: ko
 	KO_DOCKER_REPO=${IMAGE} \
     VERSION=${VERSION} \

--- a/drift-cache/Dockerfile
+++ b/drift-cache/Dockerfile
@@ -1,7 +1,8 @@
-FROM golang:1.24 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 as builder
 WORKDIR /sigs.k8s.io/external-dns
 COPY . .
-RUN make build
+RUN git config --global --add safe.directory /sigs.k8s.io/external-dns
+RUN make build.fips
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /usr/bin/


### PR DESCRIPTION
This PR implements FIPS compliance with the following changes:
- Added new make target build.fips based on the upstream make target, with:
  - Enabled dynamic linkage for the external-dns binary (`CGO_ENABLED=1`).
  - Added the `strictfipsruntime` tag to the external-dns binary.

Builder image in the Dockerfile.openshift was also updated to a FIPS compliant image.
Added builder workdir to safe directories after builder image change to ubi9 in Dockerfile.openshift.

Verification steps:
```bash
$ podman build -t quay.io/rh-ee-gpiotrow/external-dns:fips -f Containerfile.externaldns .
WARN[0000] missing "FULL_COMMIT" build argument. Try adding "--build-arg FULL_COMMIT=<VALUE>" to the command line 
[1/3] STEP 1/5: FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS drift
[1/3] STEP 2/5: WORKDIR /app
--> Using cache afa8227b21e8cd5de03de7c2f29c0b6955d06d991dd4245fdfccfb329c9100a5
--> afa8227b21e8
[1/3] STEP 3/5: COPY drift-cache/Dockerfile Dockerfile.cached
--> Using cache 16af1ce6cb64ddd8dc7fae68b76a524e24aa96823961fa35f66088cc5fdefab3
--> 16af1ce6cb64
[1/3] STEP 4/5: COPY Dockerfile.openshift Dockerfile
--> Using cache fadea127650db60e258dee16f945c0882517620d7b11866b7dabeabaabadc7b6
--> fadea127650d
[1/3] STEP 5/5: RUN test "$(sha1sum Dockerfile.cached | cut -d' ' -f1)" = "$(sha1sum Dockerfile | cut -d' ' -f1)"
--> Using cache 4af0f159fb3c4dfd612b5269019d4013a9fa835b1bfa0f41304993dff2c5d7b0
--> 4af0f159fb3c
[2/3] STEP 1/7: FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1763548439 AS builder
[2/3] STEP 2/7: COPY --from=drift /app/Dockerfile.cached .
--> Using cache 8e45e2ff92f342e0f4b24a4ebdab8dd446388a6b013ebc9df3d7d8b4abe820d5
--> 8e45e2ff92f3
[2/3] STEP 3/7: WORKDIR /workspace
--> Using cache 0889d13e4076ea507219789e6efd289d53cdc387154635fbaa75d85e69257cd4
--> 0889d13e4076
[2/3] STEP 4/7: RUN ls .
--> Using cache 761820ddf45dcd689df053f9cc34f5c6c6de267c80e498f28278f5aed398f83e
--> 761820ddf45d
[2/3] STEP 5/7: COPY . /workspace
--> Using cache 614206b8fff26757700ffd1cf6f9c6d3b818979bca74a2600b732e82cf26fa80
--> 614206b8fff2
[2/3] STEP 6/7: RUN git config --global --add safe.directory /workspace
--> Using cache 0677b72f14739adbc5f44d86dd9de2157bce9aac38e3eb03a15b319af416d430
--> 0677b72f1473
[2/3] STEP 7/7: RUN make build.fips
--> Using cache 2bc144fd61f889d5dd68ca8409db92ee9d6b8ae8f4a813668d13d2da76d982bb
--> 2bc144fd61f8
[3/3] STEP 1/12: FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:161a4e29ea482bab6048c2b36031b4f302ae81e4ff18b83e61785f40dc576f5d
[3/3] STEP 2/12: ARG FULL_COMMIT
--> Using cache 45c0d5f932219a529a9b242f91f521604d9b8fe83f1b6a279f593718b855c750
--> 45c0d5f93221
[3/3] STEP 3/12: LABEL maintainer="Red Hat, Inc."
--> Using cache 81219948823adf4614e7720119079c78ec600798d4aff3e4cd4ca788d4fe69f8
--> 81219948823a
[3/3] STEP 4/12: LABEL com.redhat.component="external-dns-container"
--> Using cache 71998c003028dd76b2fdd8ec6248af707aa7a042d4360687bf73f24d9e136519
--> 71998c003028
[3/3] STEP 5/12: LABEL name="external-dns"
--> Using cache a1f5231135706691ba88ad3d22d12fb3a3d2db94fbaffc40923a0af3810b29e8
--> a1f523113570
[3/3] STEP 6/12: LABEL version="1.3.3"
--> Using cache b415ce3f0e69a1a59776be2d0fb75dbc725f57744aed7901cf771f57c3ab53d9
--> b415ce3f0e69
[3/3] STEP 7/12: LABEL commit=${FULL_COMMIT}
--> Using cache ddecf0026160f0bb20b6cd7142308b1ba701122054131b39bfb014a7cdb3788d
--> ddecf0026160
[3/3] STEP 8/12: WORKDIR /
--> Using cache af675dc551d13d3b331e69ac91b46fccdddfd97143637a355354e00a8f35a61e
--> af675dc551d1
[3/3] STEP 9/12: COPY --from=builder /workspace/build/external-dns /
--> Using cache 2b9b2bdc045e6ebf93ac6f179c51d75c53dda77ef89b24669726118472015219
--> 2b9b2bdc045e
[3/3] STEP 10/12: COPY LICENSE /licenses/
--> Using cache be75dbc3fe10eeaec127937dfe6f5b8b7a989cbb1615a04f0821a38f58e4e08f
--> be75dbc3fe10
[3/3] STEP 11/12: USER 65532:65532
--> Using cache 852cab0fadcaf82a228744fe342ea074705b3f60a3a6aba87d215d60f29cac02
--> 852cab0fadca
[3/3] STEP 12/12: ENTRYPOINT ["/external-dns"]
--> Using cache 4dfb940f357e8a0f73cd1ea25b94d351e71e700b94aaa434972aa5e6cbbf1767
[3/3] COMMIT quay.io/rh-ee-gpiotrow/external-dns:fips
--> 4dfb940f357e
Successfully tagged quay.io/rh-ee-gpiotrow/external-dns:fips
Successfully tagged quay.io/rh-ee-gpiotrow/external-dns-operator:fips
4dfb940f357e8a0f73cd1ea25b94d351e71e700b94aaa434972aa5e6cbbf1767

$ podman push quay.io/rh-ee-gpiotrow/external-dns:fips
Getting image source signatures
Copying blob 4fe8bd6e3683 skipped: already exists  
Copying blob e33884b9ee6f skipped: already exists  
Copying blob 54a681db9b79 skipped: already exists  
Copying config 4dfb940f35 done   | 
Writing manifest to image destination

$ podman run --privileged registry.ci.openshift.org/ci/check-payload:latest scan operator --spec quay.io/rh-ee-gpiotrow/external-dns:fips
I1208 12:13:47.476785       1 main.go:313] using embedded config
I1208 12:13:47.477125       1 main.go:102] "scan" version="0.3.11-4-ga0e6b81f-dirty"
---- Successful run
```