### PR TITLE
GCP-287: UPSTREAM: 4847: Add trailing dot to NS records in Google Cloud DNS

### DIFF
--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -445,6 +445,12 @@ func newRecord(ep *endpoint.Endpoint) *dns.ResourceRecordSet {
 		}
 	}
 
+	if ep.RecordType == endpoint.RecordTypeNS {
+		for i, nsRecord := range ep.Targets {
+			targets[i] = provider.EnsureTrailingDot(nsRecord)
+		}
+	}
+
 	// no annotation results in a Ttl of 0, default to 300 for backwards-compatibility
 	var ttl int64 = googleRecordTTL
 	if ep.RecordTTL.IsConfigured() {

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -460,21 +460,25 @@ func TestNewFilteredRecords(t *testing.T) {
 		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, 1, "8.8.4.4"),
 		endpoint.NewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, 120, "8.8.4.4"),
 		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, 4000, "bar.elb.amazonaws.com"),
+		endpoint.NewEndpointWithTTL("update-test-ns.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeNS, 120, "foo.elb.amazonaws.com"),
 		// test fallback to Ttl:300 when Ttl==0 :
 		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, 0, "8.8.8.8"),
 		endpoint.NewEndpointWithTTL("update-test-mx.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeMX, 6000, "10 mail.elb.amazonaws.com"),
 		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, "8.8.8.8"),
 		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, "qux.elb.amazonaws.com"),
+		endpoint.NewEndpoint("delete-test-ns.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeNS, "foo.elb.amazonaws.com"),
 	})
 
 	validateChangeRecords(t, records, []*dns.ResourceRecordSet{
 		{Name: "update-test.zone-2.ext-dns-test-2.gcp.zalan.do.", Rrdatas: []string{"8.8.4.4"}, Type: "A", Ttl: 1},
 		{Name: "delete-test.zone-2.ext-dns-test-2.gcp.zalan.do.", Rrdatas: []string{"8.8.4.4"}, Type: "A", Ttl: 120},
 		{Name: "update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do.", Rrdatas: []string{"bar.elb.amazonaws.com."}, Type: "CNAME", Ttl: 4000},
+		{Name: "update-test-ns.zone-1.ext-dns-test-2.gcp.zalan.do.", Rrdatas: []string{"foo.elb.amazonaws.com."}, Type: "NS", Ttl: 120},
 		{Name: "update-test.zone-1.ext-dns-test-2.gcp.zalan.do.", Rrdatas: []string{"8.8.8.8"}, Type: "A", Ttl: 300},
 		{Name: "update-test-mx.zone-1.ext-dns-test-2.gcp.zalan.do.", Rrdatas: []string{"10 mail.elb.amazonaws.com."}, Type: "MX", Ttl: 6000},
 		{Name: "delete-test.zone-1.ext-dns-test-2.gcp.zalan.do.", Rrdatas: []string{"8.8.8.8"}, Type: "A", Ttl: 300},
 		{Name: "delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do.", Rrdatas: []string{"qux.elb.amazonaws.com."}, Type: "CNAME", Ttl: 300},
+		{Name: "delete-test-ns.zone-1.ext-dns-test-2.gcp.zalan.do.", Rrdatas: []string{"foo.elb.amazonaws.com."}, Type: "NS", Ttl: 300},
 	})
 }
 

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -460,7 +460,7 @@ func TestNewFilteredRecords(t *testing.T) {
 		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, 1, "8.8.4.4"),
 		endpoint.NewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, 120, "8.8.4.4"),
 		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeCNAME, 4000, "bar.elb.amazonaws.com"),
-		endpoint.NewEndpointWithTTL("update-test-ns.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeNS, 120, "foo.elb.amazonaws.com"),
+		endpoint.NewEndpointWithTTL("update-test-ns.zone-1.ext-dns-test-2.gcp.zalan.do.", endpoint.RecordTypeNS, 120, "foo.elb.amazonaws.com"),
 		// test fallback to Ttl:300 when Ttl==0 :
 		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeA, 0, "8.8.8.8"),
 		endpoint.NewEndpointWithTTL("update-test-mx.zone-1.ext-dns-test-2.gcp.zalan.do", endpoint.RecordTypeMX, 6000, "10 mail.elb.amazonaws.com"),


### PR DESCRIPTION
## Summary

Cherry-pick of upstream PR kubernetes-sigs/external-dns#4847 to fix NS record creation failures with Google Cloud DNS provider.

## Problem

NS records created via DNSEndpoint CRDs fail with Google Cloud DNS API error:

```
googleapi: Error 400: Invalid value for 'entity.change.additions[...][NS].rrdata[0]': 'ns-cloud-a1.googledomains.com', invalid
```

The Google Cloud DNS API requires NS record targets to have trailing dots, similar to CNAME, MX, and SRV records.

## Solution

Add NS record handling in `provider/google/google.go` to ensure trailing dots are added to NS record targets before sending to Google Cloud DNS API.

## Upstream Reference

- **Upstream PR**: https://github.com/kubernetes-sigs/external-dns/pull/4847
- **Merged**: November 20, 2024
- **Available in**: Upstream v0.15.1+

## Testing

Validated on management cluster with:
- ✅ **NS records via DNSEndpoint CRD**: Successfully created with trailing dots
- ✅ **Route DNS records**: Working correctly for OpenShift routes
- ✅ **Service DNS records**: ExternalName service CNAME records working

**Test logs showing success**:
```
{"level":"info","msg":"Add records: in.cluster.region.dev.gcp-hcp.devshift.net. NS [ns-cloud-a1.googledomains.com. ns-cloud-a2.googledomains.com. ns-cloud-a3.googledomains.com. ns-cloud-a4.googledomains.com.] 300"}
```

## Commits

This PR includes all 3 commits from upstream PR #4847:
1. Add trailing dot to NS records in Google Cloud DNS
2. Add unit tests
3. Update provider/google/google_test.go

## Related

- **Resolves**: https://issues.redhat.com/browse/GCP-287
- **Blocks**: https://issues.redhat.com/browse/GCP-247