### PR TITLE
Add arm64 multi-arch build support to Tekton pipelines

### DIFF
--- a/.tekton/external-dns-container-ext-dns-optr-1-3-rhel-9-pull-request.yaml
+++ b/.tekton/external-dns-container-ext-dns-optr-1-3-rhel-9-pull-request.yaml
@@ -32,6 +32,8 @@ spec:
     value:
       - linux/x86_64
       - linux/arm64
+  - name: build-image-index
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/external-dns-container-ext-dns-optr-1-3-rhel-9-pull-request.yaml
+++ b/.tekton/external-dns-container-ext-dns-optr-1-3-rhel-9-pull-request.yaml
@@ -28,6 +28,10 @@ spec:
     value: 5d
   - name: dockerfile
     value: Containerfile.externaldns
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -111,6 +115,8 @@ spec:
       default: docker
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
+    - name: build-platforms
+      type: array
     results:
     - description: ""
       name: IMAGE_URL
@@ -197,7 +203,12 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
-    - name: build-container
+    - matrix:
+        params:
+        - name: PLATFORM
+          value:
+          - $(params.build-platforms)
+      name: build-images
       params:
       - name: IMAGE
         value: $(params.output-image)
@@ -221,20 +232,24 @@ spec:
         value: $(params.build-args-file)
       - name: PRIVILEGED_NESTED
         value: $(params.privileged-nested)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      - name: BUILDAH_FORMAT
-        value: $(params.buildah-format)
+      - name: IMAGE_APPEND_PLATFORM
+        value: "true"
       runAfter:
       - prefetch-dependencies
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.7@sha256:916781b75e5f42a2e0b578b3ab3418e8bcc305168b2cd26ff41c8057e5c9ec28
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.8@sha256:4c6e3e4c3fe8a289161dfbc38a162d28a0289eb4d51f835e847f8c3677a211f3
         - name: kind
           value: task
         resolver: bundles
@@ -255,11 +270,11 @@ spec:
         value: $(params.build-image-index)
       - name: IMAGES
         value:
-        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+        - $(tasks.build-images.results.IMAGE_REF[*])
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
       runAfter:
-      - build-container
+      - build-images
       taskRef:
         params:
         - name: name

--- a/.tekton/external-dns-container-ext-dns-optr-1-3-rhel-9-push.yaml
+++ b/.tekton/external-dns-container-ext-dns-optr-1-3-rhel-9-push.yaml
@@ -26,6 +26,10 @@ spec:
     value: quay.io/redhat-user-workloads/external-dns-operator-tenant/ext-dns-optr-1-3-rhel-9/external-dns-container-ext-dns-optr-1-3-rhel-9:{{revision}}
   - name: dockerfile
     value: Containerfile.externaldns
+  - name: build-platforms
+    value:
+      - linux/x86_64
+      - linux/arm64
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -109,6 +113,8 @@ spec:
       default: docker
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
+    - name: build-platforms
+      type: array
     results:
     - description: ""
       name: IMAGE_URL
@@ -195,7 +201,12 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
-    - name: build-container
+    - matrix:
+        params:
+        - name: PLATFORM
+          value:
+          - $(params.build-platforms)
+      name: build-images
       params:
       - name: IMAGE
         value: $(params.output-image)
@@ -219,20 +230,24 @@ spec:
         value: $(params.build-args-file)
       - name: PRIVILEGED_NESTED
         value: $(params.privileged-nested)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      - name: BUILDAH_FORMAT
-        value: $(params.buildah-format)
+      - name: IMAGE_APPEND_PLATFORM
+        value: "true"
       runAfter:
       - prefetch-dependencies
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.7@sha256:916781b75e5f42a2e0b578b3ab3418e8bcc305168b2cd26ff41c8057e5c9ec28
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.8@sha256:4c6e3e4c3fe8a289161dfbc38a162d28a0289eb4d51f835e847f8c3677a211f3
         - name: kind
           value: task
         resolver: bundles
@@ -253,11 +268,11 @@ spec:
         value: $(params.build-image-index)
       - name: IMAGES
         value:
-        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+        - $(tasks.build-images.results.IMAGE_REF[*])
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
       runAfter:
-      - build-container
+      - build-images
       taskRef:
         params:
         - name: name

--- a/.tekton/external-dns-container-ext-dns-optr-1-3-rhel-9-push.yaml
+++ b/.tekton/external-dns-container-ext-dns-optr-1-3-rhel-9-push.yaml
@@ -30,6 +30,8 @@ spec:
     value:
       - linux/x86_64
       - linux/arm64
+  - name: build-image-index
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
## Summary
- Switch Tekton build pipelines from single-arch `buildah-oci-ta` to multi-platform `buildah-remote-oci-ta` with Tekton matrix expansion
- Build for both `linux/x86_64` and `linux/arm64` architectures
- The `build-image-index` task now combines per-arch images into a multi-arch OCI manifest list

## Changes
- **Both push and pull-request pipelines** (`.tekton/external-dns-container-ext-dns-optr-1-3-rhel-9-{push,pull-request}.yaml`):
  - Added `build-platforms` parameter (`linux/x86_64`, `linux/arm64`)
  - Replaced `build-container` task with `build-images` using Tekton `matrix` to fan out builds per platform
  - Switched task ref from `buildah-oci-ta:0.7` to `buildah-remote-oci-ta:0.8` (dispatches to arch-appropriate nodes via multi-platform-controller)
  - Added `SOURCE_URL` and `IMAGE_APPEND_PLATFORM` params required by the remote task
  - Updated `build-image-index` to consume `IMAGE_REF[*]` from matrix results

## Test plan
- [ ] Verify push pipeline triggers on merge to master and builds both x86_64 and arm64 images
- [ ] Verify pull-request pipeline triggers on PR and builds both architectures
- [ ] Confirm the resulting image index contains manifests for both architectures (`skopeo inspect --raw`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)