### PR TITLE
OCPBUGS-76245: Bump Go to 1.25 for CVE-2025-61729

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.12
+  tag: rhel-8-release-golang-1.25-openshift-4.22

--- a/Containerfile.externaldns
+++ b/Containerfile.externaldns
@@ -8,7 +8,7 @@ COPY Dockerfile.openshift Dockerfile
 # drift-cache/Dockerfile can be updated with the upstream contents once the Konflux version is aligned.
 RUN test "$(sha1sum Dockerfile.cached | cut -d' ' -f1)" = "$(sha1sum Dockerfile | cut -d' ' -f1)"
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18.10 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.25.7 as builder
 # dummy copy to trigger the drift detection
 COPY --from=drift /app/Dockerfile.cached .
 WORKDIR /workspace

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.25-openshift-4.22 AS builder
 WORKDIR /sigs.k8s.io/external-dns
 COPY . .
 RUN make build

--- a/drift-cache/Dockerfile
+++ b/drift-cache/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.25-openshift-4.22 AS builder
 WORKDIR /sigs.k8s.io/external-dns
 COPY . .
 RUN make build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/external-dns
 
-go 1.18
+go 1.25
 
 require (
 	cloud.google.com/go/compute v1.9.0

--- a/internal/testutils/endpoint.go
+++ b/internal/testutils/endpoint.go
@@ -42,7 +42,10 @@ func (b byAllFields) Less(i, j int) bool {
 	if b[i].DNSName == b[j].DNSName {
 		// This rather bad, we need a more complex comparison for Targets, which considers all elements
 		if b[i].Targets.Same(b[j].Targets) {
-			return b[i].RecordType <= b[j].RecordType
+			if b[i].RecordType != b[j].RecordType {
+				return b[i].RecordType < b[j].RecordType
+			}
+			return len(b[i].ProviderSpecific) < len(b[j].ProviderSpecific)
 		}
 		return b[i].Targets.String() <= b[j].Targets.String()
 	}

--- a/provider/bluecat/gateway/api_test.go
+++ b/provider/bluecat/gateway/api_test.go
@@ -55,7 +55,7 @@ func TestBluecatExpandZones(t *testing.T) {
 			got := expandZone(tc.input)
 			diff := cmp.Diff(tc.want, got)
 			if diff != "" {
-				t.Fatalf(diff)
+				t.Fatalf("%s", diff)
 			}
 		})
 	}
@@ -91,7 +91,7 @@ func TestBluecatSplitProperties(t *testing.T) {
 			got := SplitProperties(tc.input)
 			diff := cmp.Diff(tc.want, got)
 			if diff != "" {
-				t.Fatalf(diff)
+				t.Fatalf("%s", diff)
 			}
 		})
 	}

--- a/provider/dnsimple/dnsimple_test.go
+++ b/provider/dnsimple/dnsimple_test.go
@@ -105,10 +105,10 @@ func TestDnsimpleServices(t *testing.T) {
 	// Setup mock services
 	// Note: AnythingOfType doesn't work with interfaces https://github.com/stretchr/testify/issues/519
 	mockDNS := &mockDnsimpleZoneServiceInterface{}
-	mockDNS.On("ListZones", mock.AnythingOfType("*context.emptyCtx"), "1", &dnsimple.ZoneListOptions{ListOptions: dnsimple.ListOptions{Page: dnsimple.Int(1)}}).Return(&dnsimpleListZonesResponse, nil)
-	mockDNS.On("ListZones", mock.AnythingOfType("*context.emptyCtx"), "2", &dnsimple.ZoneListOptions{ListOptions: dnsimple.ListOptions{Page: dnsimple.Int(1)}}).Return(nil, fmt.Errorf("Account ID not found"))
-	mockDNS.On("ListRecords", mock.AnythingOfType("*context.emptyCtx"), "1", "example.com", &dnsimple.ZoneRecordListOptions{ListOptions: dnsimple.ListOptions{Page: dnsimple.Int(1)}}).Return(&dnsimpleListRecordsResponse, nil)
-	mockDNS.On("ListRecords", mock.AnythingOfType("*context.emptyCtx"), "1", "example-beta.com", &dnsimple.ZoneRecordListOptions{ListOptions: dnsimple.ListOptions{Page: dnsimple.Int(1)}}).Return(&dnsimple.ZoneRecordsResponse{Response: dnsimple.Response{Pagination: &dnsimple.Pagination{}}}, nil)
+	mockDNS.On("ListZones", context.Background(), "1", &dnsimple.ZoneListOptions{ListOptions: dnsimple.ListOptions{Page: dnsimple.Int(1)}}).Return(&dnsimpleListZonesResponse, nil)
+	mockDNS.On("ListZones", context.Background(), "2", &dnsimple.ZoneListOptions{ListOptions: dnsimple.ListOptions{Page: dnsimple.Int(1)}}).Return(nil, fmt.Errorf("Account ID not found"))
+	mockDNS.On("ListRecords", context.Background(), "1", "example.com", &dnsimple.ZoneRecordListOptions{ListOptions: dnsimple.ListOptions{Page: dnsimple.Int(1)}}).Return(&dnsimpleListRecordsResponse, nil)
+	mockDNS.On("ListRecords", context.Background(), "1", "example-beta.com", &dnsimple.ZoneRecordListOptions{ListOptions: dnsimple.ListOptions{Page: dnsimple.Int(1)}}).Return(&dnsimple.ZoneRecordsResponse{Response: dnsimple.Response{Pagination: &dnsimple.Pagination{}}}, nil)
 
 	for _, record := range records {
 		recordName := record.Name
@@ -124,10 +124,10 @@ func TestDnsimpleServices(t *testing.T) {
 			Data:     []dnsimple.ZoneRecord{record},
 		}
 
-		mockDNS.On("ListRecords", mock.AnythingOfType("*context.emptyCtx"), "1", record.ZoneID, &dnsimple.ZoneRecordListOptions{Name: &recordName, ListOptions: dnsimple.ListOptions{Page: dnsimple.Int(1)}}).Return(&dnsimpleRecordResponse, nil)
-		mockDNS.On("CreateRecord", mock.AnythingOfType("*context.emptyCtx"), "1", record.ZoneID, simpleRecord).Return(&dnsimple.ZoneRecordResponse{}, nil)
-		mockDNS.On("DeleteRecord", mock.AnythingOfType("*context.emptyCtx"), "1", record.ZoneID, record.ID).Return(&dnsimple.ZoneRecordResponse{}, nil)
-		mockDNS.On("UpdateRecord", mock.AnythingOfType("*context.emptyCtx"), "1", record.ZoneID, record.ID, simpleRecord).Return(&dnsimple.ZoneRecordResponse{}, nil)
+		mockDNS.On("ListRecords", context.Background(), "1", record.ZoneID, &dnsimple.ZoneRecordListOptions{Name: &recordName, ListOptions: dnsimple.ListOptions{Page: dnsimple.Int(1)}}).Return(&dnsimpleRecordResponse, nil)
+		mockDNS.On("CreateRecord", context.Background(), "1", record.ZoneID, simpleRecord).Return(&dnsimple.ZoneRecordResponse{}, nil)
+		mockDNS.On("DeleteRecord", context.Background(), "1", record.ZoneID, record.ID).Return(&dnsimple.ZoneRecordResponse{}, nil)
+		mockDNS.On("UpdateRecord", context.Background(), "1", record.ZoneID, record.ID, simpleRecord).Return(&dnsimple.ZoneRecordResponse{}, nil)
 	}
 
 	mockProvider = dnsimpleProvider{client: mockDNS}

--- a/provider/tencentcloud/cloudapi/tencentapi.go
+++ b/provider/tencentcloud/cloudapi/tencentapi.go
@@ -258,7 +258,7 @@ func dealWithError(action Action, request string, err error) bool {
 }
 
 func APIErrorRecord(apiAction Action, request string, response string, err error) {
-	log.Infof(fmt.Sprintf("APIError API: %s/%s Request: %s, Response: %s, Error: %s", apiAction.Service, apiAction.Name, request, response, err.Error()))
+	log.Infof("APIError API: %s/%s Request: %s, Response: %s, Error: %s", apiAction.Service, apiAction.Name, request, response, err.Error())
 }
 
 func APIRecord(apiAction Action, request string, response string) {
@@ -267,7 +267,7 @@ func APIRecord(apiAction Action, request string, response string) {
 	if apiAction.ReadOnly {
 		// log.Infof(message)
 	} else {
-		log.Infof(message)
+		log.Infof("%s", message)
 	}
 }
 

--- a/provider/vinyldns/vinyldns.go
+++ b/provider/vinyldns/vinyldns.go
@@ -92,7 +92,7 @@ func (p *vinyldnsProvider) Records(ctx context.Context) (endpoints []*endpoint.E
 			continue
 		}
 
-		log.Infof(fmt.Sprintf("Zone: [%s:%s]", zone.ID, zone.Name))
+		log.Infof("Zone: [%s:%s]", zone.ID, zone.Name)
 		records, err := p.client.RecordSets(zone.ID)
 		if err != nil {
 			return nil, err
@@ -101,7 +101,7 @@ func (p *vinyldnsProvider) Records(ctx context.Context) (endpoints []*endpoint.E
 		for _, r := range records {
 			if provider.SupportedRecordType(r.Type) {
 				recordsCount := len(r.Records)
-				log.Debugf(fmt.Sprintf("%s.%s.%d.%s", r.Name, r.Type, recordsCount, zone.Name))
+				log.Debugf("%s.%s.%d.%s", r.Name, r.Type, recordsCount, zone.Name)
 
 				// TODO: AAAA Records
 				if len(r.Records) > 0 {


### PR DESCRIPTION
## Summary

- Bump `go.mod` from Go 1.18 to Go 1.25 to remediate CVE-2025-61729 (crypto/x509 DoS)
- RHEL8 UBI `go-toolset` only has Go 1.24.6 which does not include the fix (requires 1.24.12+), making Go 1.25.6+ the only viable path
- Cherry-pick upstream fixes for Go 1.25 build/test incompatibilities
- Used the Claude Code `/compliance:analyze-cve` plugin to identify, analyze, and remediate the CVE
- Confirmed CVE resolution via `govulncheck` binary scan

## Changes

1. `go.mod`: `go 1.18` -> `go 1.25`
2. Fix non-constant format strings in `bluecat/gateway`, `vinyldns` (cherry-pick from upstream/master `fab82e88`)
3. Fix non-constant format strings in `tencentcloud/cloudapi` (cherry-pick from upstream/master `2661da7`)
4. Fix `internal/testutils` `ExampleSameEndpoints` sort stability for Go 1.25
5. Fix `provider/coredns` `TestCoreDNSApplyChanges` order-independent service validation (backport from master)
6. Fix `provider/dnsimple` context type mismatch (partial cherry-pick from upstream `d68fd0217`)
7. Update `Containerfile.externaldns` builder image to `ubi8/go-toolset:1.25.7`

## Verification

- All tests pass with Go 1.25.6 (`make test`)
- `govulncheck -mode binary` confirms GO-2025-4155 (CVE-2025-61729) is no longer reported

## CVE Details

- **CVE-2025-61729** / GO-2025-4155
- Excessive resource consumption in `crypto/x509.HostnameError.Error()`
- Severity: High
- https://nvd.nist.gov/vuln/detail/CVE-2025-61729