### PR TITLE
OCPBUGS-78658: Update Go to 1.25.8 for CVE-2026-25679 (release-1.2)

### DIFF
--- a/Containerfile.externaldns
+++ b/Containerfile.externaldns
@@ -8,7 +8,7 @@ COPY Dockerfile.openshift Dockerfile
 # drift-cache/Dockerfile can be updated with the upstream contents once the Konflux version is aligned.
 RUN test "$(sha1sum Dockerfile.cached | cut -d' ' -f1)" = "$(sha1sum Dockerfile | cut -d' ' -f1)"
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.25.7 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.25.8 as builder
 # dummy copy to trigger the drift detection
 COPY --from=drift /app/Dockerfile.cached .
 WORKDIR /workspace


### PR DESCRIPTION
## Summary
- Bump Go from 1.25.7 to 1.25.8 in Konflux Containerfile to fix CVE-2026-25679

## CVE Details
- **CVE:** [CVE-2026-25679](https://nvd.nist.gov/vuln/detail/CVE-2026-25679)
- **Go Vuln:** [GO-2026-4601](https://pkg.go.dev/vuln/GO-2026-4601)
- **Severity:** Moderate
- **Affected:** `net/url.Parse` — accepted malformed IPv6 host literals
- **Fixed in:** Go 1.25.8 / Go 1.26.1

## Changes
| File | Change |
|---|---|
| `Containerfile.externaldns` | `go-toolset:1.25.7` → `go-toolset:1.25.8` |