### PR TITLE
OCPBUGS-76243: UPSTREAM: <carry>: Add Konflux Containerfile

### DIFF
--- a/Containerfile.externaldns
+++ b/Containerfile.externaldns
@@ -1,0 +1,38 @@
+# Detect the drift from the upstream Dockerfile
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS drift
+WORKDIR /app
+COPY drift-cache/Dockerfile Dockerfile.cached
+COPY Dockerfile.openshift Dockerfile
+# If the command below fails it means that the Dockerfile from this repository changed.
+# You have to update the Konflux Containerfile accordingly.
+# drift-cache/Dockerfile can be updated with the upstream contents once the Konflux version is aligned.
+RUN test "$(sha1sum Dockerfile.cached | cut -d' ' -f1)" = "$(sha1sum Dockerfile | cut -d' ' -f1)"
+
+FROM registry.access.redhat.com/ubi8/go-toolset:1.18.10 as builder
+# dummy copy to trigger the drift detection
+COPY --from=drift /app/Dockerfile.cached .
+WORKDIR /workspace
+# Dummy RUN to create /workspace directory.
+# WORKDIR doesn't create the directory (at least for Podman).
+# Without this step, the following COPY may create /workspace
+# as root-owned (instead of go-toolset's default 1001)
+# leading to "Permission denied" errors during "make build"
+# when trying to write output.
+RUN ls .
+COPY . /workspace
+RUN git config --global --add safe.directory /workspace
+# Build
+RUN make build
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+ARG FULL_COMMIT
+LABEL maintainer="Red Hat, Inc."
+LABEL com.redhat.component="external-dns-container"
+LABEL name="external-dns"
+LABEL version="1.1.1"
+LABEL commit=${FULL_COMMIT}
+WORKDIR /
+COPY --from=builder /workspace/build/external-dns /
+COPY LICENSE /licenses/
+USER 65532:65532
+ENTRYPOINT ["/external-dns"]

--- a/drift-cache/Dockerfile
+++ b/drift-cache/Dockerfile
@@ -1,0 +1,12 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+WORKDIR /sigs.k8s.io/external-dns
+COPY . .
+RUN make build
+
+FROM registry.ci.openshift.org/ocp/4.12:base
+COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /usr/bin/
+ENTRYPOINT ["/usr/bin/external-dns"]
+LABEL io.openshift.release.operator="true"
+LABEL io.k8s.display-name="Kubernetes ExternalDNS" \
+      io.k8s.description="Synchronizes exposed Kubernetes Services and Ingresses with DNS providers." \
+      maintainer="<aos-network-edge-staff@redhat.com>"


### PR DESCRIPTION
Add `Containerfile.externaldns` for Konflux builds on release-1.1 branch. Uses `ubi8/go-toolset:1.18.10` for the build stage and `ubi8/ubi-minimal` for the runtime image. Includes drift detection against `Dockerfile.openshift` to catch upstream changes that need to be reflected in the Konflux build.

Related bug: https://redhat.atlassian.net/browse/OCPBUGS-76243.
