### PR TITLE
UPSTREAM: <carry>: Update DOWNSTREAM_OWNERS 2026

### DIFF
--- a/DOWNSTREAM_OWNERS
+++ b/DOWNSTREAM_OWNERS
@@ -1,19 +1,16 @@
 approvers:
   - knobunc
   - Miciah
-  - frobware
   - candita
   - rfredette
   - alebedev87
-  - miheer
   - gcs278
+  - grzpiotrowski
+  - Thealisyed
 reviewers:
-  - knobunc
-  - Miciah
-  - frobware
-  - candita
   - rfredette
   - alebedev87
-  - miheer
   - gcs278
+  - grzpiotrowski
+  - Thealisyed
 component: DNS


### PR DESCRIPTION
- Add Greg and Ali as approvers and reviewers
- Remove Andy and Miheer as they changed teams
- Remove managers and architects from reviews to reduce notification noise
