### PR TITLE
UPSTREAM: <carry>: Enforce hermetic builds and source images for Conforma compliance

### DIFF
--- a/.tekton/external-dns-container-ext-dns-optr-1-2-rhel-8-pull-request.yaml
+++ b/.tekton/external-dns-container-ext-dns-optr-1-2-rhel-8-pull-request.yaml
@@ -57,7 +57,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -69,7 +69,7 @@ spec:
       description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
       type: string
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/external-dns-container-ext-dns-optr-1-2-rhel-8-push.yaml
+++ b/.tekton/external-dns-container-ext-dns-optr-1-2-rhel-8-push.yaml
@@ -55,7 +55,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -67,7 +67,7 @@ spec:
       description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
       type: string
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string


### PR DESCRIPTION
Update Tekton pipeline defaults to pass conforma validation requirements:
- hermetic build set to true.
- build-source-image: set to true.