### PR TITLE
UPSTREAM: <carry>: OCPBUGS-24656: Ensure FIPS compliance for operand image

### DIFF
--- a/Containerfile.externaldns
+++ b/Containerfile.externaldns
@@ -21,8 +21,8 @@ WORKDIR /workspace
 RUN ls .
 COPY . /workspace
 RUN git config --global --add safe.directory /workspace
-# Build
-RUN make build
+# Build with FIPS compliance
+RUN make build.fips
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest@sha256:41c6aeb7c681d89b63b35dbb8168875cd2e7b00e9ebe1d2d3d6a3c205c9dba10
 ARG FULL_COMMIT

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,7 +1,8 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.25-openshift-4.22 AS builder
 WORKDIR /sigs.k8s.io/external-dns
 COPY . .
-RUN make build
+RUN git config --global --add safe.directory /sigs.k8s.io/external-dns
+RUN make build.fips
 
 FROM registry.ci.openshift.org/ocp/4.12:base
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /usr/bin/

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,13 @@ build: build/$(BINARY)
 build/$(BINARY): $(SOURCES)
 	CGO_ENABLED=0 go build -o build/$(BINARY) $(BUILD_FLAGS) -ldflags "$(LDFLAGS)" .
 
+# Downstream FIPS-compliant build
+.PHONY: build.fips
+build.fips: build.fips/$(BINARY)
+
+build.fips/$(BINARY): $(SOURCES)
+	CGO_ENABLED=1 go build -tags strictfipsruntime -o build/$(BINARY) $(BUILD_FLAGS) -ldflags "$(LDFLAGS)" .
+
 build.push/multiarch:
 	arch_specific_tags=()
 	for arch in $(ARCHS); do \

--- a/drift-cache/Dockerfile
+++ b/drift-cache/Dockerfile
@@ -1,7 +1,8 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.25-openshift-4.22 AS builder
 WORKDIR /sigs.k8s.io/external-dns
 COPY . .
-RUN make build
+RUN git config --global --add safe.directory /sigs.k8s.io/external-dns
+RUN make build.fips
 
 FROM registry.ci.openshift.org/ocp/4.12:base
 COPY --from=builder /sigs.k8s.io/external-dns/build/external-dns /usr/bin/


### PR DESCRIPTION
This commit implements FIPS compliance with the following changes:
- Added new make target build.fips based on the upstream make target, with:
- Enabled dynamic linkage for the external-dns binary (`CGO_ENABLED=1`).
- Added the `strictfipsruntime` tag to the external-dns binary.
- Updated `Dockerfile.openshift`, `drift-cache/Dockerfile` and `Containerfile.externaldns` to use the `build.fips` target.

