### PR TITLE
OCPBUGS-79591: Update renovate config for Go toolset 1.25

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,7 @@
       ]
     },
     {
-      "description": "Keep Go toolset on minor version 1.24",
+      "description": "Keep Go toolset on minor version 1.25",
       "matchManagers": ["dockerfile"],
       "matchFileNames": [
         "Containerfile.externaldns"
@@ -36,7 +36,7 @@
       ],
       "enabled": true,
       "versioning": "redhat",
-      "allowedVersions": "/^1\\.24(\\.|$)/",
+      "allowedVersions": "/^1\\.25(\\.|$)/",
       "schedule": [
         "after 5am on tuesday"
       ]


### PR DESCRIPTION
Update the renovate config to allow Go toolset 1.25 instead of 1.24.