### PR TITLE
OCPBUGS-79591: Prepare 1.3.4 release

### DIFF
--- a/Containerfile.externaldns
+++ b/Containerfile.externaldns
@@ -28,7 +28,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:fe688da81a696387c
 ARG FULL_COMMIT
 LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="external-dns-container"
-LABEL name="external-dns"
+LABEL name="edo/external-dns-rhel9"
 LABEL version="1.3.3"
 LABEL commit=${FULL_COMMIT}
 WORKDIR /

--- a/Containerfile.externaldns
+++ b/Containerfile.externaldns
@@ -29,7 +29,7 @@ ARG FULL_COMMIT
 LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="external-dns-container"
 LABEL name="edo/external-dns-rhel9"
-LABEL version="1.3.3"
+LABEL version="1.3.4"
 LABEL commit=${FULL_COMMIT}
 WORKDIR /
 COPY --from=builder /workspace/build/external-dns /


### PR DESCRIPTION
- Fix the `name` label in `Containerfile.externaldns` to match product security metadata required by the `check-labels` release task
- Bump the `version` label to `1.3.4`