### PR TITLE
NE-2727: Update version label to 1.3.5

### DIFF
--- a/Containerfile.externaldns
+++ b/Containerfile.externaldns
@@ -29,7 +29,7 @@ ARG FULL_COMMIT
 LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="external-dns-container"
 LABEL name="edo/external-dns-rhel9"
-LABEL version="1.3.4"
+LABEL version="1.3.5"
 LABEL cpe="cpe:/a:redhat:ext_dns_optr:1.3::el9"
 LABEL commit=${FULL_COMMIT}
 WORKDIR /


### PR DESCRIPTION
Update external-dns container version label ahead of the v1.3.5 release.