### PR TITLE
NE-2747: Update version label to 1.3.6

### DIFF
--- a/Containerfile.externaldns
+++ b/Containerfile.externaldns
@@ -29,7 +29,7 @@ ARG FULL_COMMIT
 LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="external-dns-container"
 LABEL name="edo/external-dns-rhel9"
-LABEL version="1.3.5"
+LABEL version="1.3.6"
 LABEL cpe="cpe:/a:redhat:ext_dns_optr:1.3::el9"
 LABEL commit=${FULL_COMMIT}
 WORKDIR /


### PR DESCRIPTION
Bump `version` label in `Containerfile.externaldns` from `1.3.5` to `1.3.6`.