### PR TITLE
NO-JIRA: Add Renovate rules for UBI8 images on `release-1.x` branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,6 +40,41 @@
       "schedule": [
         "after 5am on tuesday"
       ]
+    },
+    {
+      "description": "Enable Docker image updates for Red Hat UBI8 images on release-1.x",
+      "matchManagers": ["dockerfile"],
+      "matchBaseBranches": ["release-1.1", "release-1.2"],
+      "matchFileNames": [
+        "Containerfile.externaldns"
+      ],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "registry.access.redhat.com/ubi8/ubi-minimal"
+      ],
+      "enabled": true,
+      "versioning": "redhat",
+      "schedule": [
+        "after 5am on tuesday"
+      ]
+    },
+    {
+      "description": "Keep Go toolset on minor version 1.25 for release-1.x",
+      "matchManagers": ["dockerfile"],
+      "matchBaseBranches": ["release-1.1", "release-1.2"],
+      "matchFileNames": [
+        "Containerfile.externaldns"
+      ],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "registry.access.redhat.com/ubi8/go-toolset"
+      ],
+      "enabled": true,
+      "versioning": "redhat",
+      "allowedVersions": "/^1\\.25(\\.|$)/",
+      "schedule": [
+        "after 5am on tuesday"
+      ]
     }
   ],
   "tekton": {


### PR DESCRIPTION
Renovate reads config only from the default branch (`master`), which only has rules for `ubi9` images. The `release-1.1` and `release-1.2` branches use `ubi8/ubi-minimal` and `ubi8/go-toolset` in their Containerfiles, so Renovate silently skips them.

Add `matchBaseBranches`-scoped rules for both UBI8 images to enable base image digest updates and Go toolchain version bumps on release branches.