### PR TITLE
NE-2780: OCPBUGS-82447: Bump go-toolset to 1.25.10 for CVE-2026-32282

### DIFF
--- a/Containerfile.externaldns
+++ b/Containerfile.externaldns
@@ -8,7 +8,7 @@ COPY Dockerfile.openshift Dockerfile
 # drift-cache/Dockerfile can be updated with the upstream contents once the Konflux version is aligned.
 RUN test "$(sha1sum Dockerfile.cached | cut -d' ' -f1)" = "$(sha1sum Dockerfile | cut -d' ' -f1)"
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.25.8 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.25.10 as builder
 # dummy copy to trigger the drift detection
 COPY --from=drift /app/Dockerfile.cached .
 WORKDIR /workspace
@@ -29,7 +29,7 @@ ARG FULL_COMMIT
 LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="external-dns-container"
 LABEL name="external-dns"
-LABEL version="1.2.2"
+LABEL version="1.2.3"
 LABEL commit=${FULL_COMMIT}
 WORKDIR /
 COPY --from=builder /workspace/build/external-dns /


### PR DESCRIPTION
## Summary

- Bump `ubi8/go-toolset` from `1.25.8` to `1.25.10` in `Containerfile.externaldns`
- Go 1.25.8 is vulnerable to [CVE-2026-32282](https://nvd.nist.gov/vuln/detail/CVE-2026-32282) (`Root.Chmod` can follow symlinks out of the root). Go 1.25.9+ contains the fix.

## Test plan

- [ ] Konflux CI builds the container image successfully with the new toolset version
- [ ] No functional changes — only the Go compiler version used during build is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-82447`