### PR TITLE
NO-JIRA: UPSTREAM: <carry>: Bump version label to `1.2.4` and add `cpe` label in `Containerfile.externaldns`

### DIFF
--- a/Containerfile.externaldns
+++ b/Containerfile.externaldns
@@ -29,7 +29,7 @@ ARG FULL_COMMIT
 LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="external-dns-container"
 LABEL name="external-dns"
-LABEL version="1.2.3"
+LABEL version="1.2.4"
 LABEL commit=${FULL_COMMIT}
 WORKDIR /
 COPY --from=builder /workspace/build/external-dns /

--- a/Containerfile.externaldns
+++ b/Containerfile.externaldns
@@ -30,6 +30,7 @@ LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="external-dns-container"
 LABEL name="external-dns"
 LABEL version="1.2.4"
+LABEL cpe="cpe:/a:redhat:ext_dns_optr:1.2::el8"
 LABEL commit=${FULL_COMMIT}
 WORKDIR /
 COPY --from=builder /workspace/build/external-dns /


### PR DESCRIPTION
Bump the `version` label from `1.2.3` to `1.2.4` and add the `cpe` label (`cpe:/a:redhat:ext_dns_optr:1.2::el8`) in `Containerfile.externaldns` to match the operator's product security metadata.