### PR TITLE
NE-2820: UPSTREAM: <carry>: Update container version to v1.1.3 and security metadata labels

### DIFF
--- a/Containerfile.externaldns
+++ b/Containerfile.externaldns
@@ -28,8 +28,9 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ARG FULL_COMMIT
 LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="external-dns-container"
-LABEL name="external-dns"
+LABEL name="edo/external-dns-rhel8"
 LABEL version="1.1.2"
+LABEL cpe="cpe:/a:redhat:ext_dns_optr:1.1::el8"
 LABEL commit=${FULL_COMMIT}
 WORKDIR /
 COPY --from=builder /workspace/build/external-dns /

--- a/Containerfile.externaldns
+++ b/Containerfile.externaldns
@@ -29,7 +29,7 @@ ARG FULL_COMMIT
 LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="external-dns-container"
 LABEL name="edo/external-dns-rhel8"
-LABEL version="1.1.2"
+LABEL version="1.1.3"
 LABEL cpe="cpe:/a:redhat:ext_dns_optr:1.1::el8"
 LABEL commit=${FULL_COMMIT}
 WORKDIR /


### PR DESCRIPTION
Upcoming EDO release is `1.1.3`, this commit updates the version label to be consistent with operator and bundle images.

`cpe` label addition: check-labels release task enforces the cpe label to match the value from the product data file. Without this override, the UBI base image cpe label is used, which does not match and verify-conforma task fails.

`name` label change: `check-labels` task in release pipeline enforces the usage of names which correspond to product security metadata.